### PR TITLE
fixes depricated set-output GHA function

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -42,4 +42,4 @@ jobs:
         run: |
           sha_new=$(git rev-parse HEAD)
           echo $sha_new
-          echo "::set-output name=SHA::$sha_new"
+          echo "SHA=$sha_new" >> $GITHUB_OUTPUT

--- a/.github/workflows/calc_new_versions.yml
+++ b/.github/workflows/calc_new_versions.yml
@@ -74,10 +74,10 @@ jobs:
         id: clean-semver
         run: |
           if [[ "${{ needs.calculate-new-version.outputs.BranchName }}" == "main" ]]; then
-            echo "::set-output name=new_version_pip::${{ needs.calculate-new-version.outputs.MajMinPatch }}"
-            echo "::set-output name=new_version_docker::${{ needs.calculate-new-version.outputs.MajMinPatch }}"
+            echo "new_version_pip=${{ needs.calculate-new-version.outputs.MajMinPatch }}" >> $GITHUB_OUTPUT
+            echo "new_version_docker=${{ needs.calculate-new-version.outputs.MajMinPatch }}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=new_version_pip::${{ needs.calculate-new-version.outputs.MajMinPatch }}a${{ steps.find-pr.outputs.pr }}+${{ needs.calculate-new-version.outputs.Commits }}"
-            echo "::set-output name=new_version_docker::${{ needs.calculate-new-version.outputs.MajMinPatch }}-a.${{ steps.find-pr.outputs.pr }}-${{ needs.calculate-new-version.outputs.Commits }}"
+            echo "new_version_pip=${{ needs.calculate-new-version.outputs.MajMinPatch }}a${{ steps.find-pr.outputs.pr }}+${{ needs.calculate-new-version.outputs.Commits }}" >> $GITHUB_OUTPUT
+            echo "new_version_docker=${{ needs.calculate-new-version.outputs.MajMinPatch }}-a.${{ steps.find-pr.outputs.pr }}-${{ needs.calculate-new-version.outputs.Commits }}" >> $GITHUB_OUTPUT
           fi
-          echo "::set-output name=new_version_nuget::${{ needs.calculate-new-version.outputs.NuGetSemVerTag }}"
+          echo "new_version_nuget=${{ needs.calculate-new-version.outputs.NuGetSemVerTag }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
`echo ::set-output [...]` will stop working June 2023. This PR solves it. 

[https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Tested in this [branch of the CS:Go repo](https://github.com/modl-ai/csgo/actions/runs/3315379363)